### PR TITLE
Fix IO issue and build system clean up 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,9 +29,7 @@ build --cxxopt='-std=c++14'
 build:python --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build:python --linkopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build:python --define=abi=pre_cxx11_abi
-build:python --define=abi=pre_cxx11_abi_aarch64
 
 build:pre_cxx11_abi --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build:pre_cxx11_abi --linkopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build:pre_cxx11_abi --define=abi=pre_cxx11_abi
-build:pre_cxx11_abi_aarch64 --define abi=pre_cxx11_abi_aarch64 --cpu=aarch64

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,46 +25,52 @@ http_archive(
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
+git_repository(
+    name = "googletest",
+    remote = "https://github.com/google/googletest",
+    commit = "703bd9caab50b139428cea1aaff9974ebee5742e",
+    shallow_since = "1570114335 -0400"
+)
+
 # CUDA should be installed on the system locally
-#new_local_repository(
-#    name = "cuda",
-#    path = "/usr/local/cuda-10.2/targets/x86_64-linux/",
-#    build_file = "@//third_party/cuda:BUILD",
-#)
-
-http_archive(
-    name = "libtorch_pre_cxx11_abi",
-    build_file = "@//third_party/libtorch:BUILD",
-    strip_prefix = "libtorch",
-    sha256 = "ea8de17c5f70015583f3a7a43c7a5cdf91a1d4bd19a6a7bc11f074ef6cd69e27",
-    urls = ["https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.5.0.zip"],
+new_local_repository(
+    name = "cuda",
+    path = "/usr/local/cuda-10.2/",
+    build_file = "@//third_party/cuda:BUILD",
 )
 
-http_archive(
-    name = "libtorch",
-    build_file = "@//third_party/libtorch:BUILD",
-    strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.5.0.zip"],
-    sha256 = "0efdd4e709ab11088fa75f0501c19b0e294404231442bab1d1fb953924feb6b5"
+new_local_repository(
+    name = "cublas",
+    path = "/usr",
+    build_file = "@//third_party/cublas:BUILD",
 )
 
-#pip3_import(
-#    name = "trtorch_py_deps",
-#    requirements = "//py:requirements.txt"
-#)
+#############################################################################################################
+# Tarballs and fetched dependencies (default - use in cases when building from precompiled bin and tarballs)
+#############################################################################################################
 
-#load("@trtorch_py_deps//:requirements.bzl", "pip_install")
-#pip_install()
+# TODO: Uncomment these and comment out the lower section before merge into master
 
-#pip3_import(
-#    name = "py_test_deps",
-#    requirements = "//tests/py:requirements.txt"
-#)
+# http_archive(
+#    name = "libtorch",
+#    build_file = "@//third_party/libtorch:BUILD",
+#    strip_prefix = "libtorch",
+#    urls = ["https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.5.0.zip"],
+#    sha256 = "0efdd4e709ab11088fa75f0501c19b0e294404231442bab1d1fb953924feb6b5"
+# )
 
-#load("@py_test_deps//:requirements.bzl", "pip_install")
-#pip_install()
+# http_archive(
+#    name = "libtorch_pre_cxx11_abi",
+#    build_file = "@//third_party/libtorch:BUILD",
+#    strip_prefix = "libtorch",
+#    sha256 = "ea8de17c5f70015583f3a7a43c7a5cdf91a1d4bd19a6a7bc11f074ef6cd69e27",
+#    urls = ["https://download.pytorch.org/libtorch/cu102/libtorch-shared-with-deps-1.5.0.zip"],
+# )
 
-# Downloaded distributions to use with --distdir
+# Download these tarballs manually from the NVIDIA website
+# Either place them in the distdir directory in third_party and use the --distdir flag
+# or modify the urls to "file:///<PATH TO TARBALL>/<TARBALL NAME>.tar.gz
+
 #http_archive(
 #    name = "cudnn",
 #    urls = ["https://developer.nvidia.com/compute/machine-learning/cudnn/secure/7.6.5.32/Production/10.2_20191118/cudnn-10.2-linux-x64-v7.6.5.32.tgz"],
@@ -81,77 +87,61 @@ http_archive(
 #    strip_prefix = "TensorRT-7.0.0.11"
 #)
 
-## Locally installed dependencies
-# new_local_repository(
-#    name = "cudnn",
-#    path = "/usr/",
-#    build_file = "@//third_party/cudnn/local:BUILD"
-#)
+####################################################################################
+# Locally installed dependencies (use in cases of custom dependencies or aarch64)
+####################################################################################
 
-# new_local_repository(
-#   name = "tensorrt",
-#   path = "/usr/",
-#   build_file = "@//third_party/tensorrt/local:BUILD"
-#)
+# NOTE: In the case you are using just the pre-cxx11-abi path or just the cxx11 abi path 
+# with your local libtorch, just point deps at the same path to satisfy bazel.
 
-git_repository(
-    name = "googletest",
-    remote = "https://github.com/google/googletest",
-    commit = "703bd9caab50b139428cea1aaff9974ebee5742e",
-    shallow_since = "1570114335 -0400"
-)
+# NOTE: NVIDIA's aarch64 PyTorch (python) wheel file uses the CXX11 ABI unlike PyTorch's standard
+# x86_64 python distribution. If using NVIDIA's version just point to the root of the package 
+# for both versions here and do not use --config=pre-cxx11-abi
 
-
-###################################################
-#  x86_64 libraries
-###################################################
 new_local_repository(
-    name = "cuda",
-    path = "/usr/local/cuda/targets/x86_64-linux/",
-    build_file = "third_party/libs/cuda.BUILD"
+    name = "libtorch",
+    #path = "/usr/local/lib/python3.6/dist-packages/torch",
+    # TODO: Remove this and use the above line before merge into master
+    path = "/home/nvidia/.local/lib/python3.6/site-packages/torch",
+    build_file = "third_party/libtorch/BUILD"
 )
 
 new_local_repository(
-    name = "tensorrt",
-    path = "/usr/local/cuda/targets/x86_64-linux/",
-    build_file = "third_party/libs/tensorrt.BUILD"
+    name = "libtorch_pre_cxx11_abi",
+    #path = "/usr/local/lib/python3.6/dist-packages/torch",
+    # TODO: Remove this and use above line before merge into master
+    path = "/home/nvidia/.local/lib/python3.6/site-packages/torch",
+    build_file = "third_party/libtorch/BUILD"
 )
 
 new_local_repository(
     name = "cudnn",
-    path = "/usr/local/cuda/targets/x86_64-linux/",
-    build_file = "third_party/libs/cudnn.BUILD"
-)
-
-###################################################
-#  ARM libraries
-###################################################
-new_local_repository(
-    name = "cuda_aarch64",
-    path = "/usr/local/cuda/targets/aarch64-linux-gnu",
-    build_file = "third_party/cuda/BUILD"
+    path = "/usr/",
+    build_file = "@//third_party/cudnn/local:BUILD"
 )
 
 new_local_repository(
-    name = "tensorrt_aarch64",
-    path = "/usr",
-    build_file = "third_party/tensorrt/local/BUILD"
+   name = "tensorrt",
+   path = "/usr/",
+   build_file = "@//third_party/tensorrt/local:BUILD"
 )
 
-new_local_repository(
-    name = "cudnn_aarch64",
-    path = "/usr",
-    build_file = "third_party/cudnn/local/BUILD"
-)
+#########################################################################
+# Testing Dependencies (optional - comment out on aarch64)
+#########################################################################
 
-new_local_repository(
-    name = "libtorch_pre_cxx11_abi_aarch64",
-    path = "/usr/local/lib/python3.6/dist-packages/torch",
-    build_file = "third_party/libtorch/BUILD"
-)
+#pip3_import(
+#    name = "trtorch_py_deps",
+#    requirements = "//py:requirements.txt"
+#)
 
-new_local_repository(
-    name = "libtorch_aarch64",
-    path = "/usr/local/lib/python3.6/dist-packages/torch",
-    build_file = "third_party/libtorch/BUILD"
-)
+#load("@trtorch_py_deps//:requirements.bzl", "pip_install")
+#pip_install()
+
+#pip3_import(
+#    name = "py_test_deps",
+#    requirements = "//tests/py:requirements.txt"
+#)
+
+#load("@py_test_deps//:requirements.bzl", "pip_install")
+#pip_install()

--- a/core/BUILD
+++ b/core/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-   name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "core",
     hdrs = [
@@ -35,15 +20,10 @@ cc_library(
         "//core/execution",
         "//core/lowering",
         "//core/util/logging",
-    ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+	"@tensorrt//:nvinfer"
+   ] + select({
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink=True,
 )

--- a/core/conversion/BUILD
+++ b/core/conversion/BUILD
@@ -7,20 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "conversion",
     hdrs = [
@@ -36,16 +22,11 @@ cc_library(
         "//core/conversion/conversionctx",
         "//core/conversion/converters",
         "//core/conversion/evaluators",
-        "//core/util:prelude"
+        "//core/util:prelude",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )
 

--- a/core/conversion/conversionctx/BUILD
+++ b/core/conversion/conversionctx/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "conversionctx",
     hdrs = [
@@ -32,15 +17,10 @@ cc_library(
     ],
     deps = [
         "//core/util:prelude",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )
 

--- a/core/conversion/converters/BUILD
+++ b/core/conversion/converters/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "converters",
     hdrs = [
@@ -52,16 +37,11 @@ cc_library(
         "//core/conversion/var",
         "//core/conversion/tensorcontainer",
         "//core/conversion/conversionctx",
-        "//core/conversion/converters/impl/plugins"
+        "//core/conversion/converters/impl/plugins",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
 )

--- a/core/conversion/converters/BUILD
+++ b/core/conversion/converters/BUILD
@@ -29,7 +29,8 @@ cc_library(
         "impl/softmax.cpp",
         "impl/unary.cpp",
         "impl/interpolate.cpp",
-        "impl/select.cpp"
+        "impl/select.cpp",
+        "impl/stack.cpp"
     ],
     deps = [
         "@tensorrt//:nvinfer",

--- a/core/conversion/converters/BUILD
+++ b/core/conversion/converters/BUILD
@@ -28,7 +28,8 @@ cc_library(
         "impl/shuffle.cpp",
         "impl/softmax.cpp",
         "impl/unary.cpp",
-        "impl/interpolate.cpp"
+        "impl/interpolate.cpp",
+        "impl/select.cpp"
     ],
     deps = [
         "@tensorrt//:nvinfer",

--- a/core/conversion/converters/impl/plugins/BUILD
+++ b/core/conversion/converters/impl/plugins/BUILD
@@ -1,24 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
-    name = "aarch64",
-    values = {
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
     name = "use_pre_cxx11_abi",
     values = {
         "define": "abi=pre_cxx11_abi",
-    }
-)
-
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-	"cpu" : "aarch64"
     }
 )
 
@@ -33,15 +18,11 @@ cc_library(
     deps = [
         "//core/util:prelude",
         "//core/conversion/conversionctx",
+	"@tensorrt//:nvinfer",
+	"@cuda//:cudart"
     ] + select({
-	":aarch64": ["@libtorch_aarch64//:libtorch",
-	             "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-					"@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
 )

--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -2,12 +2,9 @@
 #include "core/util/prelude.h"
 #include "core/conversion/converters/converters.h"
 #include "NvInfer.h"
-#include "torch/csrc/autograd/generated/variable_factories.h"
 
 #include <ATen/ATen.h>
 #include <vector>
-
-#include <csignal>
 
 namespace trtorch {
 namespace core {

--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -1,0 +1,67 @@
+#include "torch/torch.h"
+#include "core/util/prelude.h"
+#include "core/conversion/converters/converters.h"
+#include "NvInfer.h"
+#include "torch/csrc/autograd/generated/variable_factories.h"
+
+#include <ATen/ATen.h>
+#include <vector>
+
+#include <csignal>
+
+namespace trtorch {
+namespace core {
+namespace conversion {
+namespace converters {
+namespace impl {
+namespace {
+
+auto select_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
+    .pattern({
+        "aten::select.int(Tensor(a) self, int dim, int index) -> (Tensor(a))",
+        [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+            std::cout << "select.int converter recognized" << std::endl;
+
+            auto in = args[0].ITensor();
+            auto axis  = args[1].unwrapToInt();
+            auto ind = (int32_t) args[2].unwrapToInt();
+
+            // tried: vector for input
+            //std::vector<int32_t> indices_input = {ind};
+
+            auto options = torch::TensorOptions().device(torch::kCUDA, 1).dtype(torch::kInt32);
+            at::Tensor indices = torch::tensor(torch::detail::TensorDataContainer(ind), options);
+            
+            auto weights = Weights(ctx, indices);
+            // manually setting weights
+            // weights.data.type = nvinfer1::DataType::kINT32;
+
+            auto const_layer = ctx->net->addConstant(weights.shape, weights.data);
+            const_layer->setName(util::node_info(n).c_str());
+            // manually setting output type
+            // const_layer->setOutputType(0, nvinfer1::DataType::kINT32);
+
+            auto const_out = ctx->AssociateValueAndTensor(n->outputs()[0], const_layer->getOutput(0)); 
+            
+            auto gather_layer = ctx->net->addGather(*in, *const_out, axis);
+            gather_layer->setName(util::node_info(n).c_str());
+            // manually setting output type
+            // gather_layer->setOutputType(0, nvinfer1::DataType::kINT32);
+
+            auto gather_output = ctx->AssociateValueAndTensor(n->outputs()[0], gather_layer->getOutput(0));
+
+            LOG_DEBUG("Output tensor shape: " << gather_output->getDimensions());
+            
+            // for debugging
+            // std::raise(SIGTRAP);
+
+            return true;
+        }
+    });
+
+} // namespace
+} // namespace impl
+} // namespace converters
+} // namespace conversion
+} // namespace core
+} // namespace trtorch

--- a/core/conversion/converters/impl/stack.cpp
+++ b/core/conversion/converters/impl/stack.cpp
@@ -1,0 +1,64 @@
+#include "torch/torch.h"
+#include "core/util/prelude.h"
+#include "core/conversion/converters/converters.h"
+#include "core/conversion/tensorcontainer/TensorContainer.h"
+#include "NvInfer.h"
+
+#include <ATen/ATen.h>
+#include <vector>
+
+namespace trtorch {
+namespace core {
+namespace conversion {
+namespace converters {
+namespace impl {
+namespace {
+
+auto stack_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
+    .pattern({
+        "aten::stack(Tensor[] tensors, int dim=0) -> (Tensor)",
+        [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+            auto in = args[0].IValue()->toListRef();
+            auto dim = args[1].unwrapToInt();
+
+            std::vector<nvinfer1::ITensor*> tensors; 
+            
+            for (auto t : in) {
+                nvinfer1::ITensor* itensor;
+
+                if (t.isTensor()) {
+                    auto weight = Weights(ctx, t.toTensor());
+
+                    auto const_layer = ctx->net->addConstant(weight.shape, weight.data);
+                    TRTORCH_CHECK(const_layer, "Unable to create constant layer from node: " << *n);
+
+                    itensor = const_layer->getOutput(0);
+                } else {
+                    auto cont = t.toCustomClass<TensorContainer>();
+                    itensor = cont->tensor();
+                }
+
+                auto shuffle_layer = ctx->net->addShuffle(*itensor);
+                TRTORCH_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
+                shuffle_layer->setReshapeDimensions(util::unsqueezeDims(itensor->getDimensions(), dim));
+                
+                tensors.push_back(shuffle_layer->getOutput(0));
+            }
+
+            auto concat_layer = ctx->net->addConcatenation(tensors.data(), tensors.size());
+            TRTORCH_CHECK(concat_layer, "Unable to create concatenation layer from node: " << *n);
+            concat_layer->setAxis(static_cast<int>(dim));
+            auto out = ctx->AssociateValueAndTensor(n->outputs()[0], concat_layer->getOutput(0));
+
+            LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+
+            return true;
+        }
+    });
+
+} // namespace
+} // namespace impl
+} // namespace converters
+} // namespace conversion
+} // namespace core
+} // namespace trtorch

--- a/core/conversion/evaluators/BUILD
+++ b/core/conversion/evaluators/BUILD
@@ -7,20 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "evaluators",
     hdrs = [
@@ -36,9 +22,8 @@ cc_library(
         "//core/util:prelude",
         "//core/conversion/var",
         "//core/conversion/tensorcontainer",
+        "@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch"],
-        ":use_pre_cxx11_abi_aarch64" : ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),

--- a/core/conversion/tensorcontainer/BUILD
+++ b/core/conversion/tensorcontainer/BUILD
@@ -7,20 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-	    "cpu": "aarch64",
-    },
-)
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "tensorcontainer",
     hdrs = [
@@ -31,15 +17,10 @@ cc_library(
     ],
     deps = [
         "//core/util:prelude",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
 )

--- a/core/conversion/var/BUILD
+++ b/core/conversion/var/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "var",
     hdrs = [
@@ -33,15 +18,10 @@ cc_library(
     ],
     deps = [
         "//core/util:prelude",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-			        "@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
 )

--- a/core/execution/BUILD
+++ b/core/execution/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "execution",
     hdrs = [
@@ -32,16 +17,11 @@ cc_library(
         "register_trt_op.cpp",
     ],
     deps = [
-        "//core/util:prelude"
+        "//core/util:prelude",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
 )

--- a/core/lowering/BUILD
+++ b/core/lowering/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "lowering",
     hdrs = [
@@ -36,9 +21,7 @@ cc_library(
         "//core/lowering/passes",
         "//core/util:prelude"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch"],
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-        ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True

--- a/core/lowering/passes/BUILD
+++ b/core/lowering/passes/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "passes",
     hdrs = [
@@ -42,9 +27,7 @@ cc_library(
     deps = [
         "//core/util:prelude",
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch"],
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-        ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )

--- a/core/util/BUILD
+++ b/core/util/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "prelude",
     hdrs = [
@@ -43,9 +28,7 @@ cc_library(
         "jit_util.h",
     ],
     deps = select({
-	":aarch64": ["@libtorch_aarch64//:libtorch"],
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-        ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )
@@ -76,14 +59,10 @@ cc_library(
         "build_info.h",
     ],
     deps = [
+    	"@tensorrt//:nvinfer"
     ] + select({
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
-        ":aarch64": ["@libtorch_aarch64//:libtorch"],
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
-    }) + select({
-        ":aarch64": ["@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@tensorrt//:nvinfer"]
     })
 )
 
@@ -97,16 +76,11 @@ cc_library(
     ],
     deps = [
         "//core/util/logging",
-        ":macros"
+        ":macros",
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )
 

--- a/core/util/logging/BUILD
+++ b/core/util/logging/BUILD
@@ -7,21 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
-    }
-)
-
-config_setting(
-    name="aarch64",
-    values={
-        "cpu":"aarch64"
-    },
-)
-
 cc_library(
     name = "logging",
     hdrs = [
@@ -31,15 +16,10 @@ cc_library(
         "TRTorchLogger.cpp",
     ],
     deps = [
+	"@tensorrt//:nvinfer"
     ] + select({
-        ":aarch64": ["@libtorch_aarch64//:libtorch",
-		     "@tensorrt_aarch64//:nvinfer"],
-        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch",
-				"@tensorrt//:nvinfer"],
-        ":use_pre_cxx11_abi_aarch64": ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-				       "@tensorrt_aarch64//:nvinfer"],
-        "//conditions:default":  ["@libtorch//:libtorch",
-				  "@tensorrt//:nvinfer"],
+        ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+        "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )
 

--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -82,6 +82,30 @@ nvinfer1::Dims toDimsPad(c10::List<int64_t> l, uint64_t pad_to) {
     return dims;
 }
 
+nvinfer1::Dims unpadDims(const nvinfer1::Dims& d) {
+    nvinfer1::Dims dims;
+
+    int j = 0;
+    bool pad_dims_done = false;
+
+    for (int i = 0; i < d.nbDims; i++) {
+        if (d.d[i] == 1 && !pad_dims_done) {
+            // skip over unecessary dimension
+            continue;
+        } else {
+            dims.d[j] = d.d[i];
+            j++;
+
+            // keep all other dimensions (don't skip over them)
+            pad_dims_done = true;
+        }
+    }
+
+    dims.nbDims = j;
+
+    return dims;
+}
+
 std::vector<int64_t> toVec(nvinfer1::Dims d) {
     std::vector<int64_t> dims;
     for (int i = 0; i < d.nbDims; i++) {

--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -106,6 +106,32 @@ nvinfer1::Dims unpadDims(const nvinfer1::Dims& d) {
     return dims;
 }
 
+nvinfer1::Dims unsqueezeDims(const nvinfer1::Dims& d, int pos) {
+    // acceptable range for pos is [0, d.nbDims]
+    TRTORCH_ASSERT(pos >= 0 && pos <= d.nbDims, "ERROR: Index to unsqueeze is out of bounds.");
+    
+    nvinfer1::Dims dims;
+
+    int i = 0;
+    int j = 0;
+
+    while (i <= d.nbDims) {
+        if (j != pos) {
+            dims.d[j] = d.d[i];
+            i++;
+        } else {
+            // add new dimension at pos
+            dims.d[j] = 1;
+        }
+
+        j++;
+    }
+
+    dims.nbDims = d.nbDims+1;
+
+    return dims;
+}
+
 std::vector<int64_t> toVec(nvinfer1::Dims d) {
     std::vector<int64_t> dims;
     for (int i = 0; i < d.nbDims; i++) {

--- a/core/util/trt_util.h
+++ b/core/util/trt_util.h
@@ -80,6 +80,7 @@ int64_t volume(const nvinfer1::Dims& d);
 nvinfer1::Dims toDimsPad(c10::IntArrayRef l, uint64_t pad_to);
 nvinfer1::Dims toDimsPad(c10::List<int64_t> l, uint64_t pad_to);
 nvinfer1::Dims unpadDims(const nvinfer1::Dims& d);
+nvinfer1::Dims unsqueezeDims(const nvinfer1::Dims& d, int pos);
 nvinfer1::Dims toDims(c10::IntArrayRef l);
 nvinfer1::Dims toDims(c10::List<int64_t> l);
 nvinfer1::DimsHW toDimsHW(c10::List<int64_t> l);

--- a/core/util/trt_util.h
+++ b/core/util/trt_util.h
@@ -79,6 +79,7 @@ int64_t volume(const nvinfer1::Dims& d);
 
 nvinfer1::Dims toDimsPad(c10::IntArrayRef l, uint64_t pad_to);
 nvinfer1::Dims toDimsPad(c10::List<int64_t> l, uint64_t pad_to);
+nvinfer1::Dims unpadDims(const nvinfer1::Dims& d);
 nvinfer1::Dims toDims(c10::IntArrayRef l);
 nvinfer1::Dims toDims(c10::List<int64_t> l);
 nvinfer1::DimsHW toDimsHW(c10::List<int64_t> l);

--- a/cpp/benchmark/BUILD
+++ b/cpp/benchmark/BUILD
@@ -1,5 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "use_pre_cxx11_abi",
+    values = {
+        "define": "abi=pre_cxx11_abi",
+    }
+)
+
 cc_binary(
     name = "benchmark",
     srcs = [
@@ -7,11 +14,15 @@ cc_binary(
         "timer.h"
     ],
     deps = [
-    ] = select([
-        ":aarch64": ["@libtorch_aarch64//:libtorch"],
-	     "//conditions:default": ["@libtorch//:libtorch",
-			                      "@libtorch//:caffe2",
-			                      "//cpp/api:trtorch"
-			                     ],
-	]),
+	"//cpp/api:trtorch" 
+    ] + select({
+        ":use_pre_cxx11_abi": [
+	    "@libtorch_pre_cxx11_abi//:libtorch",
+            "@libtorch_pre_cxx11_abi//:caffe2",
+	],
+	"//conditions:default": [
+	    "@libtorch//:libtorch",
+            "@libtorch//:caffe2",
+	 ]
+     })
 )

--- a/cpp/ptq/BUILD
+++ b/cpp/ptq/BUILD
@@ -1,5 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "use_pre_cxx11_abi",
+    values = {
+        "define": "abi=pre_cxx11_abi",
+    }
+)
+
 cc_binary(
     name = "ptq",
     srcs = [
@@ -8,13 +15,18 @@ cc_binary(
     deps = [
         "//cpp/ptq/benchmark",
         "//cpp/ptq/datasets:cifar10",
-        "@libtorch//:libtorch",
-        "@libtorch//:caffe2",
         "//cpp/api:trtorch",
-    ] + select([
-	":aarch64" : ["@tensorrt_aarch64//:nvinfer"],
-	"//conditions:default" : ["@tensorrt//:nvinfer"],
-		    ]),
+	"@tensorrt//:nvinfer"
+    ] + select({
+        ":use_pre_cxx11_abi": [
+            "@libtorch_pre_cxx11_abi//:libtorch",
+            "@libtorch_pre_cxx11_abi//:caffe2",
+        ],
+        "//conditions:default": [
+            "@libtorch//:libtorch",
+            "@libtorch//:caffe2",
+        ]
+    }), 
     copts = [
         "-pthread"
     ],

--- a/cpp/ptq/benchmark/BUILD
+++ b/cpp/ptq/benchmark/BUILD
@@ -1,5 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "use_pre_cxx11_abi",
+    values = {
+        "define": "abi=pre_cxx11_abi",
+    }
+)
+
 cc_library(
     name = "benchmark",
     hdrs = [
@@ -10,8 +17,15 @@ cc_library(
         "timer.h"
     ],
     deps = [
-        "@libtorch//:libtorch",
-        "@libtorch//:caffe2",
         "//cpp/api:trtorch"
-    ],
+    ] + select({
+        ":use_pre_cxx11_abi": [
+            "@libtorch_pre_cxx11_abi//:libtorch",
+            "@libtorch_pre_cxx11_abi//:caffe2",
+        ],
+        "//conditions:default": [
+            "@libtorch//:libtorch",
+            "@libtorch//:caffe2",
+        ]
+    }),
 )

--- a/cpp/ptq/datasets/BUILD
+++ b/cpp/ptq/datasets/BUILD
@@ -1,5 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "use_pre_cxx11_abi",
+    values = {
+        "define": "abi=pre_cxx11_abi",
+    }
+)
+
 cc_library(
     name = "cifar10",
     hdrs = [
@@ -8,7 +15,12 @@ cc_library(
     srcs = [
         "cifar10.cpp"
     ],
-    deps = [
-        "@libtorch//:libtorch"
-    ]
+    deps = select({
+        ":use_pre_cxx11_abi": [
+            "@libtorch_pre_cxx11_abi//:libtorch",
+        ],
+        "//conditions:default": [
+            "@libtorch//:libtorch",
+        ]
+    })
 )

--- a/cpp/trtorchc/BUILD
+++ b/cpp/trtorchc/BUILD
@@ -1,24 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
-    name = "aarch64",
-    values = {
-        "cpu" : "aarch64"
-	}
-)
-
-config_setting(
     name = "use_pre_cxx11_abi",
     values = {
         "define": "abi=pre_cxx11_abi",
-    }
-)
-
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64",
     }
 )
 
@@ -29,15 +14,15 @@ cc_binary(
     ],
     deps = [
         "//third_party/args",
-        "//cpp/api:trtorch"
+        "//cpp/api:trtorch",
     ] + select({
-        ":aarch64" : ["@libtorch_aarch64//:libtorch",
-		      "@libtorch_aarch64//:caffe2"],
-	":use_pre_cxx11_abi" : ["@libtorch_pre_cxx11_abi//:libtorch",
-         			"@libtorch_pre_cxx11_abi//:caffe2"],
-	":use_pre_cxx11_abi_aarch64" : ["@libtorch_pre_cxx11_abi_aarch64//:libtorch",
-         			"@libtorch_pre_cxx11_abi_aarch64//:caffe2"],
-	"//conditions:default": ["@libtorch//:libtorch",
-			         "@libtorch//:caffe2"],
-	}),
+        ":use_pre_cxx11_abi": [
+            "@libtorch_pre_cxx11_abi//:libtorch",
+            "@libtorch_pre_cxx11_abi//:caffe2",
+        ],
+        "//conditions:default": [
+            "@libtorch//:libtorch",
+            "@libtorch//:caffe2",
+        ]
+    }),
 )

--- a/cpp/trtorchexec/BUILD
+++ b/cpp/trtorchexec/BUILD
@@ -1,13 +1,27 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "use_pre_cxx11_abi",
+    values = {
+        "define": "abi=pre_cxx11_abi",
+    }
+)
+
 cc_binary(
     name = "trtorchexec",
     srcs = [
         "main.cpp"
     ],
     deps = [
-        "@libtorch//:libtorch",
-        "@libtorch//:caffe2",
         "//cpp/api:trtorch"
-    ],
+    ] + select({
+        ":use_pre_cxx11_abi": [
+            "@libtorch_pre_cxx11_abi//:libtorch",
+            "@libtorch_pre_cxx11_abi//:caffe2",
+        ],
+        "//conditions:default": [
+            "@libtorch//:libtorch",
+            "@libtorch//:caffe2",
+        ]
+    }),,
 )

--- a/cpp/trtorchexec/BUILD
+++ b/cpp/trtorchexec/BUILD
@@ -23,5 +23,5 @@ cc_binary(
             "@libtorch//:libtorch",
             "@libtorch//:caffe2",
         ]
-    }),,
+    }),
 )

--- a/tests/core/converters/BUILD
+++ b/tests/core/converters/BUILD
@@ -63,6 +63,10 @@ converter_test(
   name = "test_select"
 )
 
+converter_test(
+  name = "test_stack"
+)
+
 test_suite(
   name = "test_converters",
   tests = [
@@ -78,7 +82,8 @@ test_suite(
     ":test_softmax",
     ":test_unary",
     ":test_interpolate",
-    ":test_select"
+    ":test_select",
+    ":test_stack"
   ]
 )
 

--- a/tests/core/converters/BUILD
+++ b/tests/core/converters/BUILD
@@ -7,28 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64"
-    }
-)
-
-config_setting(
-    name = "aarch64",
-    values = {
-       "cpu" : "aarch64"
-       }
-)
-
-config_setting(
-    name = "x86_64",
-    values = {
-       "cpu" : "x86_64"
-       }
-)
-
 converter_test(
   name = "test_activation"
 )

--- a/tests/core/converters/BUILD
+++ b/tests/core/converters/BUILD
@@ -59,6 +59,10 @@ converter_test(
   name = "test_interpolate"
 )
 
+converter_test(
+  name = "test_select"
+)
+
 test_suite(
   name = "test_converters",
   tests = [
@@ -74,6 +78,7 @@ test_suite(
     ":test_softmax",
     ":test_unary",
     ":test_interpolate",
+    ":test_select"
   ]
 )
 

--- a/tests/core/converters/converter_test.bzl
+++ b/tests/core/converters/converter_test.bzl
@@ -10,8 +10,6 @@ def converter_test(name, visibility=None):
             "@googletest//:gtest_main",
         ] + select({
             ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-            ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
-            ":aarch64":  ["@libtorch_aarch64//:libtorch"],
             "//conditions:default":  ["@libtorch//:libtorch"],
         }),
         timeout="short"

--- a/tests/core/converters/test_select.cpp
+++ b/tests/core/converters/test_select.cpp
@@ -4,6 +4,32 @@
 #include "tests/util/util.h"
 #include "core/compiler.h"
 
+TEST(Converters, ATenSelectIntConvertsCorrectly) {
+    const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=0]()
+        %3 : Tensor = aten::select(%0, %2, %2)
+        return (%3))IR";
+    
+    auto g = std::make_shared<torch::jit::Graph>();
+
+    torch::jit::parseIR(graph, &*g);
+
+    auto in = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+
+    auto jit_in = at::clone(in);
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+    auto trt_in = at::clone(in);
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
 TEST(Converters, ATenSelectIntTwiceConvertsCorrectly) {
     const auto graph = R"IR(
       graph(%0 : Tensor):

--- a/tests/core/converters/test_select.cpp
+++ b/tests/core/converters/test_select.cpp
@@ -1,0 +1,33 @@
+#include <string>
+#include "gtest/gtest.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "tests/util/util.h"
+#include "core/compiler.h"
+
+TEST(Converters, ATenSelectIntTwiceConvertsCorrectly) {
+    const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=0]()
+        %3 : int = prim::Constant[value=3]()
+        %4 : Tensor = aten::select(%0, %2, %2)
+        %5 : Tensor = aten::select(%4, %2, %3)
+        return (%5))IR";
+    
+    auto g = std::make_shared<torch::jit::Graph>();
+
+    torch::jit::parseIR(graph, &*g);
+
+    auto in = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+
+    auto jit_in = at::clone(in);
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+    auto trt_in = at::clone(in);
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}

--- a/tests/core/converters/test_stack.cpp
+++ b/tests/core/converters/test_stack.cpp
@@ -1,0 +1,53 @@
+#include <string>
+#include "gtest/gtest.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "tests/util/util.h"
+#include "core/compiler.h"
+
+TEST(Converters, ATenStackPureTensorConvertsCorrectly) {
+    const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=3]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
+
+    auto g = std::make_shared<torch::jit::Graph>();
+    torch::jit::parseIR(graph, &*g);
+
+    auto in1 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+    auto in2 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {in1, in2});
+
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in1, in2});
+
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
+TEST(Converters, ATenStackDiffTensorConvertsCorrectly) {
+    const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Float(4, 4, 4)):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=1]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
+
+    auto g = std::make_shared<torch::jit::Graph>();
+    torch::jit::parseIR(graph, &*g);
+
+    auto in1 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+    auto in2 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {in2});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {in1});
+
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {in2});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in1});
+
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}

--- a/tests/modules/BUILD
+++ b/tests/modules/BUILD
@@ -7,28 +7,6 @@ config_setting(
     }
 )
 
-config_setting(
-    name = "use_pre_cxx11_abi_aarch64",
-    values = {
-        "define": "abi=pre_cxx11_abi",
-        "cpu" : "aarch64"
-    }
-)
-
-config_setting(
-    name = "aarch64",
-    values = {
-        "cpu" : "aarch64"
-    }
-)
-
-config_setting(
-    name = "x86_64",
-    values = {
-        "cpu" : "x86_64"
-    }
-)
-
 filegroup(
     name = "jit_models",
     srcs = glob(["**/*.jit.pt"])
@@ -97,8 +75,6 @@ cc_library(
         "@googletest//:gtest_main",
     ] + select({
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-        ":use_pre_cxx11_abi_aarch64":  ["@libtorch_pre_cxx11_abi_aarch64//:libtorch"],
-        ":aarch64" : ["@libtorch_aarch64//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),
 )

--- a/third_party/cublas/BUILD
+++ b/third_party/cublas/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+   name = "aarch64",
+   values = {
+        "cpu" : "aarch64",
+   },
+)
+
+cc_library(
+    name = "cublas_headers",
+    hdrs = ["include/cublas.h"] + glob(["include/cublas+.h"]),
+    includes = ["include/"],
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "cublas_lib",
+    shared_library = select({
+        "aarch64" : "lib/aarch64-linux-gnu/libcublas.so.10",
+        "//conditions:default" : "lib/x86_64-linux-gnu/libcublas.so.10",
+    }),
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "cublas",
+    deps = [
+        "cublas_headers",
+        "cublas_lib"
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/cuda/BUILD
+++ b/third_party/cuda/BUILD
@@ -1,10 +1,22 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+   name = "aarch64",
+   values = {
+	"cpu" : "aarch64",
+   },
+)
+
 cc_library(
     name = "cudart",
-    srcs = glob([
-        "lib/**/libcudart.so",
-    ]),
+    srcs = select({
+	":aarch64": [
+            "targets/aarch64-linux-gnu/lib/libcudart.so",
+        ],
+	"//conditions:default": [
+	    "targets/x86_64-linux/lib/libcudart.so",
+	]
+    }),
     hdrs = glob([
         "include/**/*.h",
         "include/**/*.hpp",
@@ -15,16 +27,26 @@ cc_library(
 
 cc_library(
     name = "nvToolsExt",
-    srcs = glob([
-        "lib/**/libnvToolsExt.so.1"
-    ])
+    srcs = select({
+        ":aarch64": [
+            "targets/aarch64-linux-gnu/lib/libnvToolsExt.so.1",
+        ],
+        "//conditions:default": [
+            "targets/x86_64-linux/lib/libnvToolsExt.so.1",
+        ]
+    }),
 )
 
 cc_library(
     name = "cuda",
-    srcs = glob([
-        "lib/**/*libcuda.so",
-    ]),
+    srcs = select({
+        ":aarch64": glob([
+            "targets/aarch64-linux-gnu/lib/**/lib*.so",
+        ]),
+        "//conditions:default": glob([
+            "targets/x86_64-linux/lib/**/lib*.so",
+        ])
+    }),
     hdrs = glob([
         "include/**/*.h",
         "include/**/*.hpp",
@@ -34,16 +56,3 @@ cc_library(
     linkopts = ["-Wl,-rpath,lib/"],
 )
 
-cc_library(
-    name = "cublas",
-    srcs = glob([
-        "lib/**/*libcublas.so",
-    ]),
-    hdrs = glob([
-        "include/**/*cublas*.h",
-        "include/**/*.hpp",
-        "include/**/*.inl",
-    ]),
-    includes = ["include/"],
-    linkopts = ["-Wl,-rpath,lib/"],
-)

--- a/third_party/cudnn/local/BUILD
+++ b/third_party/cudnn/local/BUILD
@@ -19,7 +19,7 @@ cc_import(
     shared_library = select({
 	"aarch64" : "lib/aarch64-linux-gnu/libcudnn.so",
 	"//conditions:default" : "lib/x86_64-linux-gnu/libcudnn.so.7.6.5",
-	}),
+    }),
     visibility = ["//visibility:private"],
 )
 

--- a/third_party/libtorch/BUILD
+++ b/third_party/libtorch/BUILD
@@ -16,7 +16,7 @@ cc_library(
 
 cc_library(
     name = 'torch',
-    hdrs = ['include'] + glob(
+    hdrs = glob(
         [
             'include/torch/**/*.h',
         ], exclude = [

--- a/third_party/tensorrt/archive/BUILD
+++ b/third_party/tensorrt/archive/BUILD
@@ -24,7 +24,7 @@ cc_library(
         "nvinfer_headers",
         "nvinfer_lib",
         "@cuda//:cudart",
-        "@cuda//:cublas",
+        "@cublas//:cublas",
         "@cudnn//:cudnn"
     ],
     visibility = ["//visibility:public"],

--- a/third_party/tensorrt/local/BUILD
+++ b/third_party/tensorrt/local/BUILD
@@ -10,22 +10,22 @@ config_setting(
 cc_library(
     name = "nvinfer_headers",
     hdrs = select({
-	":aarch64" : [
-	                "include/aarch64-linux-gnu/NvUtils.h",
-     	             ] + glob([
-                               "include/aarch64-linux-gnu/NvInfer*.h",
-                              ], exclude=[
-                                          "include/aarch64-linux-gnu/NvInferPlugin.h",
-                                          "include/aarch64-linux-gnu/NvInferPluginUtils.h"
-                             ]),
+        ":aarch64" : [
+	    "include/aarch64-linux-gnu/NvUtils.h",
+     	] + glob([
+            "include/aarch64-linux-gnu/NvInfer*.h",
+        ], exclude=[
+             "include/aarch64-linux-gnu/NvInferPlugin.h",
+             "include/aarch64-linux-gnu/NvInferPluginUtils.h"
+        ]),
 	"//conditions:default" : [
-		 	        "include/NvUtils.h",
-         			] + glob([
-                                "include/NvInfer*.h",
-                                         ], exclude=[
-                                          "include/NvInferPlugin.h",
-                                          "include/NvInferPluginUtils.h"
-                                           ]),
+            "include/NvUtils.h",
+         ] + glob([
+             "include/NvInfer*.h",
+         ], exclude=[
+             "include/NvInferPlugin.h",
+             "include/NvInferPluginUtils.h"
+         ]),
     }),
     includes = select({
         ":aarch64" : ["include/aarch64-linux-gnu"],
@@ -48,19 +48,10 @@ cc_library(
     deps = [
         "nvinfer_headers",
         "nvinfer_lib",
-    ] + select({
-	":aarch64": [
-			"@cuda_aarch64//:cudart",
-			"@cuda_aarch64//:cublas",
-			"@cudnn_aarch64//:cudnn"
-			],
-	"//conditions:default":  [
-			"@cuda//:cudart",
-			"@cuda//:cublas",
-			"@cudnn//:cudnn"
-			 ],
-    }),
-
+	"@cuda//:cudart",
+	"@cublas//:cublas",
+	"@cudnn//:cudnn"
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
@andi4191 You might need to rebase your branch to merge

The issue was in //third_party/libtorch/BUILD, there was numpy libraries
being picked as headers.

Also significantly simplifies the build system to only using the
cpu flag for configuring precompiled third party dependecies and also removes
the pre_cxx11_abi_aarch64 flag.

Streamlines WORKSPACE, deduplicating repositories. Now the user workflow
for aarch64 compilation is to configure the WORKSPACE to use all local
sources. These should be able to be used the same way on x86_64

Also discovered that the NVIDIA PyTorch distribution for aarch64 uses
the CXX11 abi so default paths for both will point to the default torch
install location for local.

This is the new build command for our Jetson 
```
bazel build --remote_cache=<cache server> --cpu=aarch64 //:libtrtorch
```

TODO's post PR 

TODO: Move from cpu to platforms
TODO: Test on both x86 and aarch64 + DLA
TODO: Before merge reset the WORKSPACE file to the default settings
TODO: Run everything through buildifier to lint BUILD files 